### PR TITLE
Fixing dashboard v1

### DIFF
--- a/SENG3150-Project/ReactVite- Frontend/src/components/Dashboard/SessionContainer_Laptop.jsx
+++ b/SENG3150-Project/ReactVite- Frontend/src/components/Dashboard/SessionContainer_Laptop.jsx
@@ -27,14 +27,13 @@ const SessionContainer_Laptop = ({sessions, setSessions, selectedSessions, DragD
                                 });
 
                                 return (
-                                    <div className="flex flex-col gap-y-5 ">
+                                    <div key={id} className="flex flex-col gap-y-5 ">
 
                                         {/* Determines if game or training was selected */}
                                         {type === 'game' ? (
                                             <>
                                                 <div className="border-white border-2 rounded-2xl">
                                                     <div
-                                                        key={id}
                                                         className="w-75 h-140 bg-white rounded-2xl flex flex-col items-center text-black "
                                                     >
                                                         <div className="text-xl w-full text-center py-3 font-bold">{month} {day}</div>

--- a/SENG3150-Project/ReactVite- Frontend/src/components/Dashboard/SessionContainer_Mobile.jsx
+++ b/SENG3150-Project/ReactVite- Frontend/src/components/Dashboard/SessionContainer_Mobile.jsx
@@ -22,14 +22,13 @@ const SessionContainer_Mobile = ({sessions, selectedSessions, setSessions}) => {
                         });
 
                         return (
-                            <div className="flex flex-col gap-y-5 items-center justify-center">
+                            <div key={id} className="flex flex-col gap-y-5 items-center justify-center">
 
                                 {/* Determines if game or training was selected */}
                                 {type === 'game' ? (
                                     <>
                                         <div className="border-white border-2 rounded-2xl">
                                             <div
-                                                key={id}
                                                 className="w-75 h-140 bg-white rounded-2xl flex flex-col items-center text-black "
                                             >
                                                 <div className="text-xl w-full text-center py-3 font-bold">{month} {day}</div>

--- a/SENG3150-Project/ReactVite- Frontend/src/components/Dashboard/SessionContainer_Mobile.jsx
+++ b/SENG3150-Project/ReactVite- Frontend/src/components/Dashboard/SessionContainer_Mobile.jsx
@@ -60,7 +60,7 @@ const SessionContainer_Mobile = ({sessions, selectedSessions, setSessions}) => {
                                                     {Object.keys(groupedActivities)
                                                         .sort((a, b) => parseInt(a) - parseInt(b))
                                                         .map((rowKey) => (
-                                                            <div className="flex gap-2 mb-2 px-3">
+                                                            <div key={`${id}-row-${rowKey}`}   className="flex gap-2 mb-2 px-3">
                                                                 {groupedActivities[rowKey].map((activity) => (
                                                                     <div key={activity.id} className="flex-1 basis-0 relative group bg-orange-100 px-4 py-2 rounded shadow">
                                                                         <div className="font-bold !k-text-center">{activity.name}</div>

--- a/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/entities/Session.java
+++ b/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/entities/Session.java
@@ -12,15 +12,7 @@ package com.example.entities;
 
 import java.sql.Date;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.CascadeType;
+import jakarta.persistence.*;
 
 import java.util.List;
 
@@ -30,9 +22,10 @@ import java.util.ArrayList;
 
 @Entity
 public class Session {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int sessionID;
+    private Integer sessionID;
 
     private Date date;
 
@@ -57,9 +50,12 @@ public class Session {
     private List<VoiceNote> voiceNotes = new ArrayList<>();
 
     @JsonIgnore
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "rollID")
     private Roll roll;
+
+    @Version
+    private Long version;
 
     public Session(){}
     public Session(Date date, User user, SessionType type) {
@@ -68,11 +64,11 @@ public class Session {
         this.type = type;
     }
 
-    public int getId() {
+    public Integer getId() {
         return sessionID;
     }
 
-    public void setId(int sessionID) {
+    public void setId(Integer sessionID) {
         this.sessionID = sessionID;
     }
 

--- a/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/entities/Session.java
+++ b/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/entities/Session.java
@@ -54,8 +54,6 @@ public class Session {
     @JoinColumn(name = "rollID")
     private Roll roll;
 
-    @Version
-    private Long version;
 
     public Session(){}
     public Session(Date date, User user, SessionType type) {

--- a/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/entities/SessionActivity.java
+++ b/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/entities/SessionActivity.java
@@ -31,6 +31,9 @@ public class SessionActivity {
     @JoinColumn(name = "activityID")
     private Activity activity;
 
+    @Version
+    private Long version;
+
     private String duration;
 
     public SessionActivity(){}

--- a/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/entities/SessionActivity.java
+++ b/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/entities/SessionActivity.java
@@ -31,9 +31,6 @@ public class SessionActivity {
     @JoinColumn(name = "activityID")
     private Activity activity;
 
-    @Version
-    private Long version;
-
     private String duration;
 
     public SessionActivity(){}

--- a/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/repositories/ActivityRepository.java
+++ b/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/repositories/ActivityRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
+
 import com.example.entities.Activity;
 import com.example.entities.ActivityType;
 
@@ -15,6 +17,8 @@ public interface ActivityRepository extends JpaRepository<Activity, Integer>{
     Activity findById(int id);
     List<Activity> findByName(String name);
     Activity findDistinctByName(String name);
+    @Query("select distinct a from Activity a where a.name = :name")
+    Optional<Activity> findDistinctByNameOptional(String name);
     List<Activity> findByDescription(String description);
     List<Activity> findByPeopleRequired(int peopleRequired);
     List<Activity> findByDuration(String duration);

--- a/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/repositories/SessionActivityRepository.java
+++ b/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/repositories/SessionActivityRepository.java
@@ -45,4 +45,6 @@ public interface SessionActivityRepository extends JpaRepository<SessionActivity
         @Param("sessionTypeId") int sessionTypeId,
         @Param("activityName") String activityName
     );
+
+    void deleteBySessionIn(List<Session> existing);
 }

--- a/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/repositories/SessionRepository.java
+++ b/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/repositories/SessionRepository.java
@@ -25,4 +25,8 @@ public interface SessionRepository extends JpaRepository<Session, Integer>{
 
     @Query(value = "SELECT s.* FROM session s INNER JOIN session_type st ON st.session_typeid = s.session_typeid WHERE st.name = :typeName AND s.date = :date", nativeQuery = true)
     Session findSessionByDateAndType(@Param("typeName") String typeName, @Param("date") Date date);
+
+    List<Session> findAllByUserId(int id);
+
+    List<Session> findAllByUser(User user);
 }

--- a/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/session_controllers/SessionController.java
+++ b/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/session_controllers/SessionController.java
@@ -4,24 +4,19 @@
 
 package com.example.session_controllers;
 
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import com.example.entities.User;
+import com.example.entities.UserService;
+import com.example.repositories.SessionTypeRepository;
+import com.example.responses.*;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import com.example.entities.Session;
-import com.example.responses.InitialSessionGrabResponse;
-import com.example.responses.GetTextNoteResponse;
-import com.example.responses.CreateSessionResponse;
-import com.example.responses.EditNoteResponse;
-import com.example.responses.DeleteSessionResponse;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @CrossOrigin(origins = "http://localhost:5173") // Adjust to match your frontend origin
@@ -30,6 +25,14 @@ public class SessionController {
 
     @Autowired
     private SessionService sessionService;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private SessionActivityService sessionActivityService;
+    @Autowired
+    private SessionTypeService sessionTypeService;
+    @Autowired
+    private SessionTypeRepository sessionTypeRepository;
 	
     // @GetMapping("/initialCall")
     // public ResponseEntity<InitialSessionGrabResponse> getSessions(){
@@ -104,5 +107,48 @@ public class SessionController {
         }
         //get result and return response
     }
-    
+
+    @PostMapping("/fetchSessions")
+    public ResponseEntity<List<FetchSessionsResponse>> fetchSessions(@CookieValue(value = "userId", required = false) String userId) {
+
+        if (userId == null) {
+            System.out.println("No user ID found in cookies");
+        }else{
+            System.out.println("USerID HERE: "+ userId);
+        }
+        try {
+
+            User user = userService.getUserByID(Integer.parseInt(userId)); // Needs to parse id here
+
+            System.out.println("WE GOT THE USER: "+user);
+
+            List<Session> sessions = sessionService.getSessionsByUser(user);
+
+            List<FetchSessionsResponse> responseList = sessions.stream().map(session -> {
+                return new FetchSessionsResponse(
+                        session.getId(),
+                        session.getDate(),
+                        session.getType(),
+                        session.getSessionActivities()
+                );
+            }).collect(Collectors.toList());
+
+            return new ResponseEntity<>(responseList, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+    @PutMapping("/updateSessions")
+    public ResponseEntity<String> updateSessions(@RequestBody List<SyncSessionsResponse> sessions,  @CookieValue(value = "userId", required = false) String userId) {
+        try {
+            if (userId == null) return ResponseEntity.status(401).body("No user ID cookie");
+            sessionService.replaceUserSessions(userService.getUserByID(Integer.parseInt(userId)), sessions);
+            return ResponseEntity.ok("Sessions updated successfully.");
+        } catch (IllegalArgumentException iae) {
+            return ResponseEntity.badRequest().body(iae.getMessage());  // <-- see exact reason in Network tab
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(500).body(e.getMessage());
+        }
+    }
 }

--- a/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/session_controllers/SessionService.java
+++ b/SENG3150-Project/SprintBoot- Backend/demo/src/main/java/com/example/session_controllers/SessionService.java
@@ -4,12 +4,18 @@
 
 package com.example.session_controllers;
 
+import com.example.entities.*;
+import com.example.repositories.ActivityRepository;
+import com.example.responses.SyncSessionsActivityResponse;
+import com.example.responses.SyncSessionsResponse;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.repositories.SessionRepository;
 import com.example.repositories.SessionTypeRepository;
 import com.example.repositories.TextNoteRepository;
-import com.example.entities.Session;
 
 import java.util.List;
 
@@ -18,14 +24,16 @@ public class SessionService {
     
     private final SessionRepository sessionRepository;
     private final SessionTypeRepository sessionTypeRepository;
+    private final ActivityRepository activityRepository;
     private final TextNoteRepository textNoteRepository;
 
     public SessionService(SessionRepository sessionRepository,
-        SessionTypeRepository sessionTypeRepository,
-        TextNoteRepository textNoteRepository) {
+        SessionTypeRepository sessionTypeRepository, TextNoteRepository textNoteRepository, ActivityRepository activityRepository
+    ) {
         this.sessionRepository = sessionRepository;
         this.sessionTypeRepository = sessionTypeRepository;
         this.textNoteRepository = textNoteRepository;
+        this.activityRepository = activityRepository;
     }
 
     // public List<Session> getTrainingSessions() {
@@ -87,5 +95,85 @@ public class SessionService {
             System.out.println("Error deleting session: " + e.getMessage());
             return false;
         }
+    }
+
+    @Autowired
+    EntityManager em;
+    public void deleteAllUserSessions(User user){
+        try {
+            List<Session> sessions = sessionRepository.findByUser(user);
+            sessionRepository.deleteAll(sessions);
+            em.flush();
+            em.clear();
+        }  catch (Exception e) {
+            System.out.println("Error deleting sessions: " + e.getMessage());
+        }
+    }
+    public List<Session> getSessionsByUser(User user) {
+        return sessionRepository.findByUser(user);
+    }
+
+
+    private void prevalidate(List<SyncSessionsResponse> sessions) {
+        for (int i = 0; i < sessions.size(); i++) {
+            var dto = sessions.get(i);
+            if (dto.getSessionTypeId() == null || dto.getSessionTypeId() <= 0)
+                throw new IllegalArgumentException("session[" + i + "]: sessionTypeId required");
+
+            int finalI = i;
+            sessionTypeRepository.findById(dto.getSessionTypeId())
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "session[" + finalI + "]: sessionTypeId " + dto.getSessionTypeId() + " not found"));
+        }
+    }
+
+    @Transactional
+    public void replaceUserSessions(User user, List<SyncSessionsResponse> sessions){
+
+        prevalidate(sessions);
+
+        deleteAllUserSessions(user);
+
+        int i = 0;
+
+        for (SyncSessionsResponse session : sessions) {
+            Session s = new Session();
+            s.setUser(user);
+            s.setDate(session.getDate());
+
+            if (session.getSessionTypeId() == null) {
+                throw new IllegalArgumentException("session[" + i + "]: sessionTypeId is required");
+            }
+
+            int finalI = i;
+            SessionType sessionType = sessionTypeRepository.findById(session.getSessionTypeId()).orElseThrow(() -> new IllegalArgumentException("session[" + finalI + "]: sessionTypeId "
+                    + session.getSessionTypeId() + " not found"));
+            s.setType(sessionType);
+
+            Roll r = new Roll();
+//            r.setId(s.getId());
+//            s.setRoll(r);
+
+            int i1 = 0;
+            for(SyncSessionsActivityResponse sessionActivity : session.getActivities()){
+                SessionActivity sa = new SessionActivity();
+                sa.setSession(s);
+                sa.setRow(sessionActivity.getRow());
+                sa.setDuration(sessionActivity.getDuration().toString());
+
+                int finalI1 = i;
+                Activity a = activityRepository.findDistinctByNameOptional(sessionActivity.getName()).orElseThrow(() -> new IllegalArgumentException("session[" + finalI + "] activity[" + finalI1 + "]: name '"
+                        + sessionActivity.getName() + "' not found"));
+                sa.setActivity(a);
+
+
+                s.getSessionActivities().add(sa);
+                i1++;
+            }
+
+            sessionRepository.save(s);
+            i++;
+        }
+        sessionRepository.flush();
     }
 }


### PR DESCRIPTION
Acceptance Criteria:
When you login with with Stuart the data from the backend should be preloaded onto the left hand-side vertical bar. 
It should be May 2, May 7, May 9 and May 4. 

When you click on the session it should become selected (known by being highlighted orange).

Once selected you should see all the activities inside the session. 

Moving or deleting an activity and reloading the page should be consistent among sessions. SO changes you make apply.

Inspecting the dashboard and looking in the console should provide 0 errors of the page.

Known Issue:
Adding activities doesn't work yet because they do not reflect the activities in the db. 